### PR TITLE
Fixes discovered while debugging other mods

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,9 +1,19 @@
 # q2admin.so linux makefile
 
+# This builds in the native mode of the current OS by default.
+
+# Note that you might need to install the 32-bit libc package
+# if it isn't already installed on your platform.
+# Examples:
+# sudo apt-get install ia32-libs
+# sudo apt-get install libc6-dev-i386
+# On Ubuntu 16.x use sudo apt install libc6-dev-i386
+
 #this nice line comes from the linux kernel makefile
 ARCH := $(shell uname -m | sed -e s/i.86/i386/ -e s/sun4u/sparc64/ -e s/arm.*/arm/ -e s/sa110/arm/ -e s/alpha/axp/)
 
-#ARCH=i386
+# On 64-bit OS use the command: setarch i386 make all
+# to obtain the 32-bit binary DLL on 64-bit Linux.
 
 CC = gcc -std=gnu99
 

--- a/g_local.h
+++ b/g_local.h
@@ -601,7 +601,7 @@ typedef struct
 		qboolean  private_command_got[PRIVATE_COMMANDS];
 		char   serverip[16];
 		char   cmdlist_stored[256];
-		int    cmdlist;
+		unsigned int    cmdlist;
 		int    cmdlist_timeout;
 		int    userid;
 		int    newcmd_timeout;
@@ -610,17 +610,13 @@ typedef struct
 		int    speedfreeze;
 		int    enteredgame;
 		//*** UPDATE END ***
-	}
-	
-proxyinfo_t;
+	} proxyinfo_t;
 
 typedef struct
 	{
 		byte   inuse;
 		char   name[16];
-	}
-	
-proxyreconnectinfo_t;
+	} proxyreconnectinfo_t;
 
 #define MAXDETECTRETRIES   3
 
@@ -994,7 +990,7 @@ extern int    checkvar_poll_time;
 typedef struct
 	{
 		long    reconnecttimeout;
-		int     retrylistidx;
+		unsigned int     retrylistidx;
 		char    userinfo[MAX_INFO_STRING + 45];
 	}
 	

--- a/g_main.c
+++ b/g_main.c
@@ -82,7 +82,7 @@ void ShutdownGame (void)
 	if(!dllloaded) return;
 
 //*** UPDATE START ***
-	if (whois_active)
+	if (whois_details)
 	{
 		whois_write_file();
 		gi.TagFree (whois_details);

--- a/zb_ban.c
+++ b/zb_ban.c
@@ -766,7 +766,7 @@ void banRun(int startarg, edict_t *ent, int client)
 	char *cp;
 	int clienti, num;
 	unsigned int i, save;
-	qboolean like, all, re;
+	qboolean like, all, re = FALSE;
 	baninfo_t *newentry;
 	char savecmd[256];
 	char strbuffer[256];

--- a/zb_cmd.c
+++ b/zb_cmd.c
@@ -2496,7 +2496,8 @@ static qboolean client_command_is_mod_exploit (edict_t *ent, int client)
 qboolean doClientCommand(edict_t *ent, int client, qboolean *checkforfloodafter)
 {
 //*** UPDATE START ***
-	unsigned int i, cnt, sameip;
+	int i;
+	unsigned int cnt, sameip;
 	char abuffer[256];
 	char stemp[1024];
 	char response[2048];
@@ -2589,8 +2590,11 @@ qboolean doClientCommand(edict_t *ent, int client, qboolean *checkforfloodafter)
 		}
 	else if(proxyinfo[client].clientcommand & CCMD_ZPROXYCHECK2) // check for proxy string
 		{
+			//QW// eliminate unreferenced variables
+			/*
 			char *a1 = gi.argv(1);
 			char *a2 = gi.argv(2);
+			*/
 			
 			if(!zbotdetect || !proxyinfo[client].inuse)
 				{

--- a/zb_flood.c
+++ b/zb_flood.c
@@ -561,9 +561,10 @@ void muteRun(int startarg, edict_t *ent, int client)
 	SKIPBLANK(text);
 	
 	enti = getClientFromArg(client, ent, &clienti, text, &text);
+	seconds = q2a_atoi(text);
 	
 	// make sure the text doesn't overflow the internal buffer...
-	if(enti && isdigit(*text) && (seconds = q2a_atoi(text)) >= 0)
+	if(enti && isdigit(*text) && seconds >= 0)
 		{
 			if(seconds)
 				{

--- a/zb_init.c
+++ b/zb_init.c
@@ -1438,7 +1438,7 @@ void ClientUserinfoChanged (edict_t *ent, char *userinfo)
 	qboolean passon;
 
 //*** UPDATE START ***
-	char *s = Info_ValueForKey (userinfo, "name");
+	//char *s = Info_ValueForKey (userinfo, "name");
 	char tmptext[128];
 	char *cl_max_temp;
 	char *timescale_temp;


### PR DESCRIPTION
Comments in commits just about sum up the minor changes. 
ShutdownGame in q2admin would throw null pointer exception when calling gi.TagFree(whois_details) when the game mod was terminated early if via gi.error() server_ip was empty string. The logic error was testing whois_active, the integer, not the allocated pointer we're supposed to free.