### PR TITLE
Add ARM architecture support

### DIFF
--- a/g_main.c
+++ b/g_main.c
@@ -48,6 +48,8 @@ void *hdll = NULL;
 	#define DLLNAME "gamei386.real.so"
 #elif defined __x86_64__
 	#define DLLNAME "gamex86_64.real.so"
+#elif defined __arm__
+	#define DLLNAME "gamearm.real.so"
 #else
 	#error Unknown architecture
 #endif


### PR DESCRIPTION
Tested on raspbian, on a raspberry 3B+ arm V8

Why do not simply writte : 
```
	#define DLLNAME   "game$ARCH.real.so"
```
?